### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Output: '00:00:00'
 
 ```sh
 {{value_given_milliseconds | durationFormat: 'ms':'ddhhmmss'}}
-{{value_given_seconds | durationFormat: 's':'ddhhmms'}}
+{{value_given_seconds | durationFormat: 's':'ddhhmmss'}}
 
 Output: '00d, 00h, 00m, 00s'
 ```


### PR DESCRIPTION
In the example code the second argument had a typo, it was missing an s.

Changed: ddhhmms -> ddhhmmss

Without this the code resulted in displaying the raw amount of seconds instead of displaying days, hours, minutes and seconds.